### PR TITLE
Active pane style

### DIFF
--- a/styles/code-ribbon.less
+++ b/styles/code-ribbon.less
@@ -48,11 +48,14 @@ atom-pane-container.cr-primary-container {
   // TODO: for empty-patches, will have the style for the fuzzy-finder here
 
   // need this to 'pop' to user
-  .cr-patch.active atom-text-editor {
-    background-color: #282c39;
-  }
   .cr-patch.active {
+    // empty patch color
     background-color: #282c39;
+
+    // patches with stuff
+    atom-text-editor {
+      background-color: #282c39;
+    }
   }
 }
 

--- a/styles/code-ribbon.less
+++ b/styles/code-ribbon.less
@@ -52,12 +52,12 @@ atom-pane-container.cr-primary-container {
     
     // highlight active tabs to indicate active patch
     .tab {
-      background-color: #434957;
+      background-color: lighten(@tab-background-color-active, 10%);
     }
 
     // empty patches are entirely highlited
     // this may be removed with the fuzzy-finder search in the middle
-    background-color: #434957;
+    background-color: lighten(@base-background-color, 10%);
 
   }
 }

--- a/styles/code-ribbon.less
+++ b/styles/code-ribbon.less
@@ -51,11 +51,6 @@ atom-pane-container.cr-primary-container {
   .cr-patch.active {
     // empty patch color
     background-color: #282c39;
-
-    // patches with stuff
-    atom-text-editor {
-      background-color: #282c39;
-    }
   }
 }
 

--- a/styles/code-ribbon.less
+++ b/styles/code-ribbon.less
@@ -49,8 +49,16 @@ atom-pane-container.cr-primary-container {
 
   // need this to 'pop' to user
   .cr-patch.active {
-    // empty patch color
-    background-color: #282c39;
+    
+    // highlight active tabs to indicate active patch
+    .tab {
+      background-color: #434957;
+    }
+
+    // empty patches are entirely highlited
+    // this may be removed with the fuzzy-finder search in the middle
+    background-color: #434957;
+
   }
 }
 

--- a/styles/code-ribbon.less
+++ b/styles/code-ribbon.less
@@ -43,6 +43,19 @@ atom-pane-container.cr-primary-container {
   }
 }
 
+// production css
+atom-pane-container.cr-primary-container {
+  // TODO: for empty-patches, will have the style for the fuzzy-finder here
+
+  // need this to 'pop' to user
+  .cr-patch.active atom-text-editor {
+    background-color: #282c39;
+  }
+  .cr-patch.active {
+    background-color: #282c39;
+  }
+}
+
 // dev-only css:
 atom-pane-container.cr-primary-container.cr-dev-active {
   .cr-patch::before {


### PR DESCRIPTION
Austin's preference for active pane styling. Change the background of text-editor to a different color gray to 'pop' to user

<img width="975" alt="Screen Shot 2019-04-07 at 2 24 45 PM" src="https://user-images.githubusercontent.com/22582326/55687945-ed911c80-5940-11e9-90f6-d96c04aa6c7e.png">
<img width="976" alt="Screen Shot 2019-04-07 at 2 22 54 PM" src="https://user-images.githubusercontent.com/22582326/55687946-eff37680-5940-11e9-8a50-850d1b6acbea.png">
<img width="682" alt="Screen Shot 2019-04-07 at 2 23 17 PM" src="https://user-images.githubusercontent.com/22582326/55687951-11546280-5941-11e9-8c3c-e2834bee54c5.png">
