### PR TITLE
Manual control over scroll snap

### DIFF
--- a/lib/code-ribbon-manager.js
+++ b/lib/code-ribbon-manager.js
@@ -33,6 +33,7 @@ class CodeRibbonManager {
     this.viewRegistry = viewRegistry;
     this.cr_primary_container = atom.workspace.getCenter().paneContainer;
     this.subscriptions = new CompositeDisposable();
+    this.abortcontroller = new AbortController();
     this.active_patch = null;
 
     if (state.previousContainerSerializedRoot) {
@@ -69,6 +70,25 @@ class CodeRibbonManager {
     }
     this.cr_primary_container.getRoot().initialize();
     this.cr_primary_container.getElement().classList.add("cr-primary-container");
+
+    // install scroll listener:
+    this.cr_primary_container.getElement().addEventListener(
+      'scroll',
+      e => {
+        this.handle_scroll(e);
+      },
+      {
+        signal: this.abortcontroller.signal,
+      }
+    );
+    // update when config changes:
+    // this.scrollAlignTimeout = atom.config.get("code-ribbon.autoscroll_timeout");
+    this.subscriptions.add(atom.config.observe(
+      "code-ribbon.snap_alignment.autoscroll_timeout",
+      newValue => {
+        this.scrollAlignTimeout = newValue;
+      }
+    ));
 
     // the command for overview mode:
     this.subscriptions.add(atom.commands.add('atom-workspace', {
@@ -193,6 +213,23 @@ class CodeRibbonManager {
       prevRoot.destroy();
     }
     this.cr_primary_container.getRoot().cr_update();
+  }
+
+  handle_scroll(e) {
+    if (this.scrollAlignTimeout == 0) return false;
+    window.clearTimeout(this.whileScrolling);
+    this.whileScrolling = setTimeout(() => {
+      crdebug("manager scroll snapping last event:", e, "this:", this);
+      let distance_cutoff = atom.config.get("code-ribbon.snap_alignment.distance_cutoff");
+      if (distance_cutoff.slice(-1) == "%") {
+        let col_width = this.cr_primary_container.getRoot().get_first_visible_strip().getElement().getBoundingClientRect().width;
+        let percentage = parseInt(distance_cutoff.slice(0, -1));
+        distance_cutoff = col_width * (percentage / 100);
+      }
+      this.cr_primary_container.getRoot().align_ribbon_to_nearest_snap_point({
+        nearby_cutoff_px: distance_cutoff,
+      });
+    }, 1000 * this.scrollAlignTimeout); // ms timeout
   }
 
   install_new_root_crrc() {

--- a/lib/code-ribbon-manager.js
+++ b/lib/code-ribbon-manager.js
@@ -251,6 +251,7 @@ class CodeRibbonManager {
   destroy() {
     crdebug("CodeRibbonManager destroy()");
     this.subscriptions.dispose();
+    this.abortcontroller.abort();
     this.cr_primary_container.getRoot().destroy();
     var previousContainerRoot = atom.deserializers.deserialize(this.previousContainerSerializedRoot);
     this.cr_primary_container.setRoot(previousContainerRoot);

--- a/lib/code-ribbon-manager.js
+++ b/lib/code-ribbon-manager.js
@@ -218,6 +218,11 @@ class CodeRibbonManager {
   handle_scroll(e) {
     if (this.scrollAlignTimeout == 0) return false;
     window.clearTimeout(this.whileScrolling);
+    // managed scrolls disable the snapping while active
+    if (this.cr_primary_container.getElement().classList.contains('cr-managed-scroll-active')) {
+      // crdebug("ignore cr managed scroll");
+      return false;
+    }
     this.whileScrolling = setTimeout(() => {
       crdebug("manager scroll snapping last event:", e, "this:", this);
       let distance_cutoff = atom.config.get("code-ribbon.snap_alignment.distance_cutoff");

--- a/lib/code-ribbon-manager.js
+++ b/lib/code-ribbon-manager.js
@@ -33,6 +33,7 @@ class CodeRibbonManager {
     this.viewRegistry = viewRegistry;
     this.cr_primary_container = atom.workspace.getCenter().paneContainer;
     this.subscriptions = new CompositeDisposable();
+    this.active_patch = null;
 
     if (state.previousContainerSerializedRoot) {
       this.previousContainerSerializedRoot = state.previousContainerSerializedRoot;
@@ -46,6 +47,15 @@ class CodeRibbonManager {
         this.previousContainerSerializedRoot
       );
     }
+
+    // watch focus of Patches
+    this.subscriptions.add(atom.workspace.observeActivePane((pane) => {
+      if (pane.cr_update) {
+        // it's a Patch
+        this.active_patch = pane;
+      }
+    }));
+
     crdebug("Replacing container root with our new one!");
     this.cr_primary_container.getRoot().destroy();
     if (

--- a/lib/code-ribbon-patch.js
+++ b/lib/code-ribbon-patch.js
@@ -253,6 +253,10 @@ class CodeRibbonPatch extends Pane {
     return pane_stuff;
   }
 
+  isVisible() {
+    return this.parent.isVisible();
+  }
+
   /**
    * open a file in this editor, will replace any existing item
    * @param {URI} n_initialpath URI to open

--- a/lib/code-ribbon-ribbon-container.js
+++ b/lib/code-ribbon-ribbon-container.js
@@ -351,7 +351,7 @@ class CodeRibbonRibbonContainer extends PaneAxis {
       let ap;
       if (new_hpps < this.prev_hpps) {
         // view is getting smaller
-        if (getActivePatchOrMostRecent().isVisible()) {
+        if (getActivePatchOrMostRecent() && getActivePatchOrMostRecent().isVisible()) {
           // prefer to keep the active focus patch on screen
           ap = getActivePatchOrMostRecent();
           crss = ap.parent;

--- a/lib/code-ribbon-ribbon-container.js
+++ b/lib/code-ribbon-ribbon-container.js
@@ -11,13 +11,15 @@ const {
   PaneAxis,
   metrics,
   global_cr_update, // eslint-disable-line no-unused-vars
-  get_crrc
+  get_crrc,
+  get_cr_panecontainer
 } = require('./cr-base');
 const {
   scrollPatchIntoView,
   getActivePatchClientWidth,
   getPreferredLineLengthCharacters,
-  getTextEditorBaseCharacterWidth
+  getTextEditorBaseCharacterWidth,
+  getActivePatchOrMostRecent
 } = require('./cr-common');
 
 const CodeRibbonSingleStrip = require('./code-ribbon-single-strip');
@@ -63,10 +65,10 @@ class CodeRibbonRibbonContainer extends PaneAxis {
     this.getElement().classList.add("cr-ribbon-container");
 
     this.resize_observer = new ResizeObserver(modifications => {
-      for (let modification of modifications) { // eslint-disable-line no-unused-vars
-        // crdebug("ResizeObserver modification:", modification);
-        this.recalc_width();
-      }
+      // for (let modification of modifications) { // eslint-disable-line no-unused-vars
+      //   crdebug("ResizeObserver modification:", modification);
+      // }
+      this.recalc_width();
     });
 
     this.resize_observer.observe(
@@ -328,10 +330,75 @@ class CodeRibbonRibbonContainer extends PaneAxis {
   }
 
   recalc_width() {
-    const widthpercent = 100 / this.getHorizontalPatchesPerScreen();
-    this.children.map((child) => {
-      child.getElement().style.flexBasis = widthpercent.toString() + "%";
-    });
+    let new_hpps = this.getHorizontalPatchesPerScreen();
+    const widthpercent = 100 / new_hpps;
+
+    if (new_hpps == this.prev_hpps) {
+      this.children.map((child) => {
+        child.getElement().style.flexBasis = widthpercent.toString() + "%";
+      });
+      this.align_ribbon_to_nearest_snap_point({scroll_behavior: 'instant'});
+    }
+    else {
+      crdebug("HPPS is changing from", this.prev_hpps, "to", new_hpps);
+      this.children.map((child) => {
+        child.getElement().classList.add("cr-resize-active");
+      });
+
+      const crpc = get_cr_panecontainer();
+      // check which strip needs to stay on screen:
+      let crss;
+      let ap;
+      if (new_hpps < this.prev_hpps) {
+        // view is getting smaller
+        if (getActivePatchOrMostRecent().isVisible()) {
+          // prefer to keep the active focus patch on screen
+          ap = getActivePatchOrMostRecent();
+          crss = ap.parent;
+        }
+        else {
+          crss = this.get_first_visible_strip();
+        }
+      }
+      else {
+        // view is getting wider
+        // ap = getActivePatchOrMostRecent();
+        crss = this.get_first_visible_strip();
+      }
+
+      if (! crss) {
+        crlogger.error("recalc_width: no visible strip");
+      }
+
+      this.children.map((child) => {
+        child.getElement().style.flexBasis = widthpercent.toString() + "%";
+      });
+
+      // wait for next frame
+      setTimeout(() => {
+        if (ap && !ap.isVisible()) {
+          crdebug("HPPS changed: keeping focused Patch in view");
+          scrollPatchIntoView(ap, undefined, {
+            scroll_behavior: 'instant'
+          });
+        }
+        else {
+          let crpc_bounds = crpc.element.getBoundingClientRect();
+          let crss_bounds = crss.element.getBoundingClientRect();
+          let scrolldiff = crss_bounds.left - crpc_bounds.left;
+          crpc.element.scrollBy({
+            left: scrolldiff,
+            behavior: 'instant'
+          });
+        }
+
+        this.children.map((child) => {
+          child.getElement().classList.remove("cr-resize-active");
+        });
+      });
+
+      this.prev_hpps = new_hpps;
+    }
   }
 
   cr_add_strip(index = this.children.length, new_children = null) {
@@ -456,6 +523,55 @@ class CodeRibbonRibbonContainer extends PaneAxis {
     else {
       crlogger.error("No empty patch at the ribbon tail?", crss);
     }
+  }
+
+  get_first_visible_strip() {
+    let crss;
+    for (let i=0; i<this.children.length; i++) {
+      crss = this.children[i];
+      if (crss.isVisible()) {
+        break;
+      }
+    }
+    if (! crss.isVisible()) {
+      crlogger.error("failed to find a visible column within the Ribbon!");
+      return undefined;
+    }
+    return crss;
+  }
+
+  /**
+   * move the ribbon the minimal amount such that the Patches are aligned with
+   * screen edges
+   * @param  {Number} [nearby_cutoff_px=0] zero/falsey to disable, do not scroll if further away than n pixels
+   * @return {bool} if scrolling was needed/started
+   */
+  align_ribbon_to_nearest_snap_point(
+      {
+        nearby_cutoff_px = null,
+        scroll_behavior = 'smooth'
+      }={}
+    ) {
+    let crpc = get_cr_panecontainer();
+    // find a visible column
+    let crss = this.get_first_visible_strip();
+    if (! crss) {
+      crlogger.error("align_ribbon_to_nearest_snap_point: no visible strip");
+      return false;
+    }
+    let crpc_bounds = crpc.element.getBoundingClientRect();
+    let crss_bounds = crss.element.getBoundingClientRect();
+
+    let scrolldiff = crss_bounds.left - crpc_bounds.left;
+
+    if (Math.abs(scrolldiff) < 1) return false;
+    if (nearby_cutoff_px && Math.abs(scrolldiff) > nearby_cutoff_px) return false;
+
+    crpc.element.scrollBy({
+      left: scrolldiff,
+      behavior: scroll_behavior
+    });
+    return true;
   }
 
 }

--- a/lib/code-ribbon-ribbon-container.js
+++ b/lib/code-ribbon-ribbon-container.js
@@ -182,6 +182,7 @@ class CodeRibbonRibbonContainer extends PaneAxis {
         atom.workspace.getActivePane(),
         () => {
           // global_cr_update();
+          this.model.align_ribbon_to_nearest_snap_point();
         }
       );
     }, 0);

--- a/lib/cr-base.js
+++ b/lib/cr-base.js
@@ -220,5 +220,6 @@ module.exports = {
   },
   global_cr_update,
   get_crrc,
-  get_cr_panecontainer
+  get_cr_panecontainer,
+  get_cr_module
 }

--- a/lib/cr-common.js
+++ b/lib/cr-common.js
@@ -3,7 +3,8 @@ const {
   crdebug,
   crlogger,
   fuzzyFinderProjectView,
-  get_cr_panecontainer
+  get_cr_panecontainer,
+  get_cr_module
 } = require('./cr-base');
 
 var scrollIntoView = require('scroll-into-view');
@@ -75,6 +76,10 @@ module.exports = {
     return atom.config.get("code-ribbon.pane_count_calc.pane_count_vertical_number");
   },
 
+  getActivePatchOrMostRecent() {
+    return get_cr_module().main_CRM.active_patch;
+  },
+
   getActivePatchClientWidth() {
     return atom.workspace.getActivePane().element.clientWidth;
   },
@@ -97,7 +102,12 @@ module.exports = {
     return d.YYYYMMDDHHMMSS();
   },
 
-  scrollPatchIntoView (patch, callback, {skip_visible_check = false}={}) {
+  scrollPatchIntoView (
+      patch, callback, {
+        skip_visible_check = false,
+        scroll_behavior = 'smooth'
+      }={}
+    ) {
     // callback(reached_target: bool)
     // primary container is what has scrollLeft nonzero
     var crpc = get_cr_panecontainer();
@@ -169,7 +179,7 @@ module.exports = {
     setTimeout(() => {
       crpc.element.scrollTo({
         left: target_scroll,
-        behavior: 'smooth'
+        behavior: scroll_behavior
       });
     });
 

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     },
     "pane_count_calc": {
       "type": "object",
+      "title": "Patch count calculation",
       "order": 30,
       "properties": {
         "pane_count_horizontal_mode": {
@@ -134,6 +135,27 @@
           "description": "Add a patch to the current column"
         }
       ]
+    },
+    "snap_alignment": {
+      "type": "object",
+      "title": "Horizontal Scroll Snap",
+      "properties": {
+        "autoscroll_timeout": {
+          "title": "Delay until columns are auto-aligned to screen",
+          "description": "Wait this number of seconds after scrolling to automatically align the viewport to the nearest patch column. Set to zero to disable the auto-snapping to columns. Values between 0 and 0.5 are not recommended for physical scrollwheel users.",
+          "default": 1.0,
+          "type": "number",
+          "minimum": 0,
+          "maximum": 30
+        },
+        "distance_cutoff": {
+          "title": "Max distance to align",
+          "description": "How close do you have to be to a column for the auto-snap to align? You can express this either as a percentage (of the current column width) or as a number of pixels.",
+          "default": "20%",
+          "type": "string",
+          "pattern": "^[0-9]+%?$"
+        }
+      }
     }
   },
   "devDependencies": {

--- a/styles/code-ribbon.less
+++ b/styles/code-ribbon.less
@@ -12,12 +12,7 @@ atom-pane-container.cr-primary-container {
   flex-direction: column;
   // overflow-x: visible;
   overflow-y: hidden;
-  scroll-snap-type: x proximity;
   scroll-behavior: smooth;
-  &.cr-overview-active,
-  &.cr-managed-scroll-active {
-    scroll-snap-type: none;
-  }
 
   atom-pane-resize-handle.horizontal {
     display: none;
@@ -46,11 +41,12 @@ atom-pane-container.cr-primary-container {
       flex-grow: 0;
       flex-shrink: 0;
 
-      // stay attached to a border
-      scroll-snap-align: start;
-
       // change width visually
       transition: flex-basis 0.3s ease;
+    }
+    atom-pane-axis.cr-vertical-strip.cr-resize-active {
+      // used to avoid the side effects while HPPS is changing
+      transition: none;
     }
 
     // .atom-pane-axis.cr-vertical-strip:first-child,


### PR DESCRIPTION
A lot of smaller UX quirks (#104 #68 #26) seem to come from the poor implementation of scroll-snap in chrome/electron.

Thus, I think we should just take control over the behavior ourselves so that we can have a more reliable and customizable scroll-snap. Doing so helps to solve the other issues linked as well.